### PR TITLE
Add no-cache to makefile for rebuilt dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 req:
-	pip3 install -r requirements.txt
+	pip3 install -r requirements.txt --no-cache-dir
 
 black:
 	python3 -m black .


### PR DESCRIPTION
Had a lot of issues with code-server and plugins. Changing to a different dockerized environment for development, and I'm adding the no-cache option to help with this